### PR TITLE
Call HashNode() in Generate if node is not hashed (#23)

### DIFF
--- a/proofs/tree.go
+++ b/proofs/tree.go
@@ -275,6 +275,9 @@ func (doctree *DocumentTree) Generate() error {
 
 	hashes := make([][]byte, len(doctree.leaves))
 	for i, leaf := range doctree.leaves {
+		if (! leaf.Hashed) || (len(leaf.Hash) == 0) {
+			leaf.HashNode(doctree.hash)
+		}
 		hashes[i] = leaf.Hash
 	}
 	doctree.merkleTree.Generate(hashes, doctree.hash)


### PR DESCRIPTION
Since field "filled" of DocumentTree is used to protect tree building period  from later building and proof generating or proving period, so function Generate() is the right place for checking if any leafnode has been hashed or not 

fixes #23 



